### PR TITLE
removing example_api and hmpps-auth local instance references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# ms-bold-lrs-service
+# hmpps-learner-records-api
+The hmpps-learner-records-api retrieves Unique Learner Number (ULN) and Personal Learning Record (PLR) for matching
+individuals from the Learning Records Service (LRS) data held by the Education and Skills Funding Agency (EFSA) at Department
+for Education (DfE).
 
-Generated from https://github.com/ministryofjustice/hmpps-template-kotlin. Please see the readme of that for extra info.
-
-This is our experimental repo for our microservice, but it is quickly becoming an actual piece of work.
-
-Auth has been temporarily commented out.
+This repository has been generated from https://github.com/ministryofjustice/hmpps-template-kotlin.
 
 ## Endpoints
 
-This service runs on `http://localhost:8080` by default.
+This service runs on:
+* Local: `http://localhost:8080`
+* Dev: `https://learner-records-api-dev.hmpps.service.justice.gov.uk/`
 
 ### `POST:/learners`
 This endpoint is to search for learners by their demographic information.
@@ -148,17 +149,19 @@ docker-compose --profile=<local/development> --env-file .env.<dev/local> up --bu
 As mentioned before there are two profiles.
 
 `local` will run:
-1. HMPPS-Auth
+1. HMPPS-Auth - Use the guidance [here](https://github.com/moj-analytical-services/dmet-bold/wiki/RR-Pilot-%E2%80%90-LRS-API-%E2%80%90-HMPPS-Auth#make-oauth-request)
+to get the access_token from the local instance of `hmpps-auth`.
 2. Wiremock API
 3. This Service
 
-Or `development` will run
-1. HMPPS-Auth
-2. This Service
+Or `development` will run:
+1. This Service
 
-_Instead of the wiremock API, this profile will attempt connection to the LRS Dev environment._
+_Instead of the wiremock API, this profile will attempt connection to the LRS Dev environment. This profile will also
+require you to connect to the `hmpps-auth` Dev environment._
 
-
+Follow the guidance [here](https://github.com/moj-analytical-services/dmet-bold/wiki/RR-Pilot-%E2%80%90-LRS-API-%E2%80%90-HMPPS-Auth#client-credentials)
+to get the access_token from the `hmpps-auth` Dev environment.
 
 E.g.
 ```bash
@@ -179,7 +182,7 @@ Open a terminal either in IntelliJ or in a separate window, ensuring you are in 
 
 Either ensure that you have set the environment variables above or if you would prefer not to set them, you can prefix the command with the following: 
 ```bash
-ORG_PASSWORD={pass};PFX_FILE_PASSWORD={pass};SPRING_PROFILES_ACTIVE=local;UK_PRN={pass}
+ORG_PASSWORD={pass};PFX_FILE_PASSWORD={pass};SPRING_PROFILES_ACTIVE=local;UK_PRN={pass};VENDOR_ID={pass}
 ```
 
 Run the following command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    profiles:
+      - local
+    networks:
+      - hmpps
+    container_name: hmpps-auth
+    ports:
+      - "8090:8080"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
+    environment:
+      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=dev
+      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+
   lrs-api:
     image: "wiremock/wiremock:latest"
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,4 @@
 services:
-  hmpps-auth:
-    image: quay.io/hmpps/hmpps-auth:latest
-    profiles:
-      - local
-      - development
-    networks:
-      - hmpps
-    container_name: hmpps-auth
-    ports:
-      - "8090:8080"
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
-    environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=dev
-      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
-
   lrs-api:
     image: "wiremock/wiremock:latest"
     profiles:
@@ -46,9 +29,6 @@ services:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/health/ping" ]
     environment:
       - SERVER_PORT=8080
-      - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
-      # TODO: Remove this URL and replace with outgoing service URLs
-      - EXAMPLE_URL=http://hmpps-learner-records-api:8080
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
       - UK_PRN=${UK_PRN}
       - ORG_PASSWORD=${ORG_PASSWORD}

--- a/helm_deploy/hmpps-learner-records-api/values.yaml
+++ b/helm_deploy/hmpps-learner-records-api/values.yaml
@@ -26,10 +26,6 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    hmpps-learner-records-api:
-      # Example client registration secrets
-      EXAMPLE_API_CLIENT_ID: "TEMPLATE_KOTLIN_API_CLIENT_ID"
-      EXAMPLE_API_CLIENT_SECRET: "TEMPLATE_KOTLIN_API_CLIENT_SECRET"
     application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
     app-config-variables:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,8 +10,6 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
     LRS_BASE_URL: "https://cmp-ws.dev.lrs.education.gov.uk"
     LRS_PFX_PATH: "WebServiceClientCert.pfx"
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,7 +12,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     # Template kotlin calls out to itself to provide an example of a service call
     # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://learner-records-api-dev.hmpps.service.justice.gov.uk"
     LRS_BASE_URL: "https://cmp-ws.dev.lrs.education.gov.uk"
     LRS_PFX_PATH: "WebServiceClientCert.pfx"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,7 +12,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     # Template kotlin calls out to itself to provide an example of a service call
     # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://learner-records-api-preprod.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,8 +10,6 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: "applicationinsights.dev.json"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,8 +7,6 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    # Template kotlin calls out to itself to provide an example of a service call
-    # TODO: This should be replaced by a call to a different service, or removed
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,6 @@ generic-service:
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     # Template kotlin calls out to itself to provide an example of a service call
     # TODO: This should be replaced by a call to a different service, or removed
-    EXAMPLE_API_URL: "https://learner-records-api.hmpps.service.justice.gov.uk"
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/WebClientConfiguration.kt
@@ -3,37 +3,17 @@ package uk.gov.justice.digital.hmpps.learnerrecordsapi.config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.web.reactive.function.client.WebClient
-import uk.gov.justice.hmpps.kotlin.auth.authorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${example-api.url}") val exampleApiBaseUri: String,
   @Value("\${hmpps-auth.url}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
-  @Value("\${api.timeout:20s}") val timeout: Duration,
 ) {
   // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services
   // TODO: Remove the health ping if no call outs to other services are made
   @Bean
   fun hmppsAuthHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(hmppsAuthBaseUri, healthTimeout)
-
-  // TODO: This is an example health bean for checking other services and should be removed / replaced
-  @Bean
-  fun exampleApiHealthWebClient(builder: WebClient.Builder): WebClient = builder.healthWebClient(exampleApiBaseUri, healthTimeout)
-
-  // TODO: This is an example bean for calling other services and should be removed / replaced
-  @Bean
-  fun exampleApiWebClient(
-    authorizedClientManager: OAuth2AuthorizedClientManager,
-    builder: WebClient.Builder,
-  ): WebClient = builder.authorisedWebClient(
-    authorizedClientManager,
-    registrationId = "example-api",
-    url = exampleApiBaseUri,
-    timeout,
-  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/health/HealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/health/HealthPingCheck.kt
@@ -8,5 +8,4 @@ import uk.gov.justice.hmpps.kotlin.health.HealthPingCheck
 // HMPPS Auth health ping is required if your service calls HMPPS Auth to get a token to call other services
 // TODO: Remove the health ping if no call outs to other services are made
 @Component("hmppsAuth")
-class HmppsAuthHealthPing(@Qualifier("hmppsAuthHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
-
+class HealthPingCheck(@Qualifier("hmppsAuthHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/health/HealthPingCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/health/HealthPingCheck.kt
@@ -10,6 +10,3 @@ import uk.gov.justice.hmpps.kotlin.health.HealthPingCheck
 @Component("hmppsAuth")
 class HmppsAuthHealthPing(@Qualifier("hmppsAuthHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)
 
-// TODO: Example ping health check calling out to other services
-@Component("exampleApi")
-class ExampleApiHealthPing(@Qualifier("exampleApiHealthWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,13 +1,5 @@
 hmpps-auth:
-  url: "http://localhost:8090/auth"
-
-# example client configuration for calling out to other services
-# TODO: Remove / replace this configuration
-example-api:
-  url: "http://localhost:8080"
-  client:
-    id: "example-api-client"
-    secret: "example-api-client-secret"
+  url: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
 
 lrs:
   base-url: "https://cmp-ws.dev.lrs.education.gov.uk"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 hmpps-auth:
-  url: "http://localhost:8090/auth"
+  url: "http://hmpps-auth:8080/auth"
 
 lrs:
   base-url: "http://lrs-api:8080"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,13 +1,5 @@
 hmpps-auth:
-  url: "http://localhost:8090/auth"
-
-# example client configuration for calling out to other services
-# TODO: Remove / replace this configuration
-example-api:
-  url: "http://localhost:8080"
-  client:
-    id: "example-api-client"
-    secret: "example-api-client-secret"
+  url: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
 
 lrs:
   base-url: "http://lrs-api:8080"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 hmpps-auth:
-  url: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+  url: "http://localhost:8090/auth"
 
 lrs:
   base-url: "http://lrs-api:8080"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,16 +25,6 @@ spring:
           hmpps-auth:
             token-uri: ${hmpps-auth.url}/oauth/token
 
-        registration:
-          # example client registration for calling out to other services
-          # TODO: Remove / replace this registration
-          example-api:
-            provider: hmpps-auth
-            client-id: ${example-api.client.id}
-            client-secret: ${example-api.client.secret}
-            authorization-grant-type: client_credentials
-            scope: read
-
 server:
   port: 8080
   servlet:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/IntegrationTestBase.kt
@@ -7,13 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.ExampleApiExtension
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.ExampleApiExtension.Companion.exampleApi
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.HmppsAuthApiExtension.Companion.hmppsAuth
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
-@ExtendWith(HmppsAuthApiExtension::class, ExampleApiExtension::class)
+@ExtendWith(HmppsAuthApiExtension::class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("test")
 abstract class IntegrationTestBase {
@@ -32,6 +30,5 @@ abstract class IntegrationTestBase {
 
   protected fun stubPingWithResponse(status: Int) {
     hmppsAuth.stubHealthPing(status)
-    exampleApi.stubHealthPing(status)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/health/HealthCheckTest.kt
@@ -30,7 +30,6 @@ class HealthCheckTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("status").isEqualTo("DOWN")
       .jsonPath("components.hmppsAuth.status").isEqualTo("DOWN")
-      .jsonPath("components.exampleApi.status").isEqualTo("DOWN")
   }
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,14 +8,6 @@ management.endpoint:
 hmpps-auth:
   url: "http://localhost:8090/auth"
 
-# example client configuration for calling out to other services
-# TODO: Remove / replace this configuration
-example-api:
-  url: "http://localhost:8091"
-  client:
-    id: "example-api-client"
-    secret: "example-api-client-secret"
-
 lrs:
   base-url: "http://localhost:8082"
   pfx-path: "WebServiceClientCert.pfx"


### PR DESCRIPTION
- Removed example_api references and tests
- Removed hmpps-auth local instance from docker for dev as can use the hmpps-auth dev as client/role is setup
- Will need another refactor to get rid of calling hmpps-auth within the service as we don't actually need this