### PR TITLE
Missing SSL no longer stops application starting.

### DIFF
--- a/.github/workflows/kotlin_validate.yml
+++ b/.github/workflows/kotlin_validate.yml
@@ -37,11 +37,6 @@ jobs:
           cache-dependency-path: |
             *.gradle*
             **/gradle-wrapper.properties
-      - name: Write Certificate file
-        shell: bash
-        run: |
-          echo "Decoding the Certificate"
-          echo "${{ secrets.CERTIFICATE }}" | base64 --decode > WebServiceClientCert.pfx
       - name: gradlew check
         env:
           cache-name: kotlin-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-learner-recor
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
-COPY WebServiceClientCert.pfx /app/WebServiceClientCert.pfx
-RUN ls -la /app/WebServiceClientCert.pfx
 
 USER 2000
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ Once downloaded, add the `WebServiceClientCert.pfx` to the root project director
 
 
 ### Starting the service
+
+Insert these two lines into the Dockerfile if running locally (as well as ensuring you have the SSL Certificate in the root directory):
+```
+COPY WebServiceClientCert.pfx /app/WebServiceClientCert.pfx
+RUN ls -la /app/WebServiceClientCert.pfx
+```
+
 Use the docker compose file to start the services - HMPPS-Auth, Wiremock for mocking LRS API Response and this microservice.
 
 Run:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
@@ -5,6 +5,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
 import retrofit2.converter.jaxb.JaxbConverterFactory
@@ -14,21 +15,29 @@ class HttpClientConfiguration(
   @Value("\${lrs.pfx-path}") val pfxFilePath: String,
   @Value("\${lrs.base-url}") val baseUrl: String,
 ) {
-  fun sslHttpClient(): OkHttpClient {
-    log.info("Building HTTP Client With SSL")
-    val sslContextConfiguration = SSLContextConfiguration(pfxFilePath)
-    val sslContext = sslContextConfiguration.createSSLContext()
-
-    val trustManager = sslContextConfiguration.getTrustManager()
-
+  fun buildSSLHttpClient(): OkHttpClient {
+    log.info("Building HTTP client with SSL")
     val loggingInterceptor = HttpLoggingInterceptor()
     loggingInterceptor.level = Level.BODY
 
-    val httpClientBuilder = OkHttpClient.Builder()
-      .sslSocketFactory(sslContext.socketFactory, trustManager)
-      .addInterceptor(loggingInterceptor)
+    try {
+      val sslContextConfiguration = SSLContextConfiguration(pfxFilePath)
+      val sslContext = sslContextConfiguration.createSSLContext()
+      val trustManager = sslContextConfiguration.getTrustManager()
 
-    return httpClientBuilder.build()
+      val httpClientBuilder = OkHttpClient.Builder()
+        .sslSocketFactory(sslContext.socketFactory, trustManager)
+        .addInterceptor(loggingInterceptor)
+
+      log.info("HTTP client with SSL built successfully!")
+      return httpClientBuilder.build()
+    } catch (e: Exception) {
+      log.info(e.message + " Falling back to HTTP client without SSL")
+      val httpClientBuilder = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+
+      return httpClientBuilder.build()
+    }
   }
 
   fun retrofit(): Retrofit {
@@ -36,7 +45,7 @@ class HttpClientConfiguration(
 
     return Retrofit.Builder()
       .baseUrl(baseUrl)
-      .client(sslHttpClient())
+      .client(buildSSLHttpClient())
       .addConverterFactory(JaxbConverterFactory.create())
       .build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
@@ -5,7 +5,6 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
 import retrofit2.converter.jaxb.JaxbConverterFactory

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/LearnersResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/LearnersResource.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.openapi.FindByDemographicA
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.service.LRSService
 
 @RestController
-@PreAuthorize("hasRole('ROLE_LEARNER_RECORDS_SEARCH__RW')")
+//@PreAuthorize("hasRole('ROLE_LEARNER_RECORDS_SEARCH__RW')")
 @RequestMapping(value = ["/learners"], produces = ["application/json"])
 class LearnersResource(
   private val lrsService: LRSService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/LearnersResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/LearnersResource.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.openapi.FindByDemographicA
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.service.LRSService
 
 @RestController
-//@PreAuthorize("hasRole('ROLE_LEARNER_RECORDS_SEARCH__RW')")
+@PreAuthorize("hasRole('ROLE_LEARNER_RECORDS_SEARCH__RW')")
 @RequestMapping(value = ["/learners"], produces = ["application/json"])
 class LearnersResource(
   private val lrsService: LRSService,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSService.kt
@@ -27,9 +27,7 @@ class LRSService(
 
   private val log: LoggerUtil = LoggerUtil(javaClass)
 
-  private fun lrsClient(): LRSApiServiceInterface {
-    return httpClientConfiguration.retrofit().create(LRSApiServiceInterface::class.java)
-  }
+  private fun lrsClient(): LRSApiServiceInterface = httpClientConfiguration.retrofit().create(LRSApiServiceInterface::class.java)
 
   private fun parseError(xmlString: String): MIAPAPIException? {
     val regex = Regex("<ns10:MIAPAPIException[\\s\\S]*?</ns10:MIAPAPIException>")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSService.kt
@@ -21,13 +21,15 @@ import kotlin.reflect.full.declaredMemberProperties
 class LRSService(
   @Autowired
   private val httpClientConfiguration: HttpClientConfiguration,
-  private val lrsClient: LRSApiServiceInterface = httpClientConfiguration.retrofit()
-    .create(LRSApiServiceInterface::class.java),
   @Autowired
   private val appConfig: AppConfig,
 ) {
 
   private val log: LoggerUtil = LoggerUtil(javaClass)
+
+  private fun lrsClient(): LRSApiServiceInterface {
+    return httpClientConfiguration.retrofit().create(LRSApiServiceInterface::class.java)
+  }
 
   private fun parseError(xmlString: String): MIAPAPIException? {
     val regex = Regex("<ns10:MIAPAPIException[\\s\\S]*?</ns10:MIAPAPIException>")
@@ -45,7 +47,7 @@ class LRSService(
 
     log.debug("Calling LRS API")
 
-    val lrsResponse = lrsClient.findLearnerByDemographics(requestBody)
+    val lrsResponse = lrsClient().findLearnerByDemographics(requestBody)
     val lrsResponseBody = lrsResponse.body()?.body?.findLearnerResponse
 
     if (lrsResponse.isSuccessful && lrsResponseBody != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/PLRService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/PLRService.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HttpClientConfiguration
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.logging.LoggerUtil
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.LearningEventsResponse
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.MIAPAPIException
@@ -18,12 +19,12 @@ import javax.xml.bind.JAXBContext
 class PLRService(
   @Autowired
   private val httpClientConfiguration: HttpClientConfiguration,
-  private val lrsClient: uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface = httpClientConfiguration.retrofit()
-    .create(uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface::class.java),
   @Autowired
   private val appConfig: AppConfig,
 ) {
   private val log: LoggerUtil = LoggerUtil(javaClass)
+
+  private fun lrsClient(): LRSApiServiceInterface = httpClientConfiguration.retrofit().create(LRSApiServiceInterface::class.java)
 
   private fun parseError(xmlString: String): MIAPAPIException? {
     val regex = Regex("<ns10:MIAPAPIException[\\s\\S]*?</ns10:MIAPAPIException>")
@@ -40,7 +41,7 @@ class PLRService(
       .transformToLRSRequest(appConfig.ukprn(), appConfig.password(), appConfig.vendorId())
     log.debug("Calling LRS API")
 
-    val plrResponse = lrsClient.getLearnerLearningEvents(requestBody)
+    val plrResponse = lrsClient().getLearnerLearningEvents(requestBody)
     val learningEvents = plrResponse.body()?.body?.learningEventsResponse
 
     if (plrResponse.isSuccessful && learningEvents != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LRSServiceTest.kt
@@ -14,8 +14,11 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.create
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HttpClientConfiguration
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.FindLearnerBody
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.FindLearnerEnvelope
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.FindLearnerResponse
@@ -33,6 +36,7 @@ import java.time.LocalDate
 class LRSServiceTest {
 
   private lateinit var httpClientConfigurationMock: HttpClientConfiguration
+  private lateinit var retrofitMock: Retrofit
   private lateinit var lrsApiServiceInterfaceMock: uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface
   private lateinit var appConfigMock: AppConfig
 
@@ -41,10 +45,13 @@ class LRSServiceTest {
   @BeforeEach
   fun setup() {
     httpClientConfigurationMock = mock(HttpClientConfiguration::class.java)
+    retrofitMock = mock(Retrofit::class.java)
     lrsApiServiceInterfaceMock =
-      mock(uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface::class.java)
+      mock(LRSApiServiceInterface::class.java)
+    `when`(httpClientConfigurationMock.retrofit()).thenReturn(retrofitMock)
+    `when`(retrofitMock.create(LRSApiServiceInterface::class.java)).thenReturn(lrsApiServiceInterfaceMock)
     appConfigMock = mock(AppConfig::class.java)
-    lrsService = LRSService(httpClientConfigurationMock, lrsApiServiceInterfaceMock, appConfigMock)
+    lrsService = LRSService(httpClientConfigurationMock, appConfigMock)
     `when`(appConfigMock.ukprn()).thenReturn("test")
     `when`(appConfigMock.password()).thenReturn("pass")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/PLRServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/PLRServiceTest.kt
@@ -14,8 +14,10 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import retrofit2.Response
+import retrofit2.Retrofit
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.AppConfig
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HttpClientConfiguration
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.LearningEventsEnvelope
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.MIAPAPIException
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.exceptions.LRSException
@@ -30,7 +32,8 @@ import java.time.LocalDate
 class PLRServiceTest {
 
   private lateinit var httpClientConfigurationMock: HttpClientConfiguration
-  private lateinit var lrsApiServiceInterfaceMock: uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface
+  private lateinit var retrofitMock: Retrofit
+  private lateinit var lrsApiServiceInterfaceMock: LRSApiServiceInterface
   private lateinit var appConfigMock: AppConfig
 
   private lateinit var plrService: PLRService
@@ -38,10 +41,13 @@ class PLRServiceTest {
   @BeforeEach
   fun setup() {
     httpClientConfigurationMock = mock(HttpClientConfiguration::class.java)
+    retrofitMock = mock(Retrofit::class.java)
     lrsApiServiceInterfaceMock =
-      mock(uk.gov.justice.digital.hmpps.learnerrecordsapi.interfaces.LRSApiServiceInterface::class.java)
+      mock(LRSApiServiceInterface::class.java)
+    `when`(httpClientConfigurationMock.retrofit()).thenReturn(retrofitMock)
+    `when`(retrofitMock.create(LRSApiServiceInterface::class.java)).thenReturn(lrsApiServiceInterfaceMock)
     appConfigMock = mock(AppConfig::class.java)
-    plrService = PLRService(httpClientConfigurationMock, lrsApiServiceInterfaceMock, appConfigMock)
+    plrService = PLRService(httpClientConfigurationMock, appConfigMock)
     `when`(appConfigMock.ukprn()).thenReturn("test")
     `when`(appConfigMock.password()).thenReturn("pass")
     `when`(appConfigMock.vendorId()).thenReturn("01")


### PR DESCRIPTION
The ssl certificate is checked for at call-time. 

For instance, you could:

- Deploy the app without the certificate
- Add it in at some point
- The app will immediately start using it, without need for restarting the app

A very small overhead is incurred by checking at call-time. If we don't want that, then I can make it so it only checks at startup.