### PR TITLE
Added Configurable Timeout To Http Client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     exclude(group = "io.swagger.core.v3")
   }
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+  testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
+
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
   }
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")
-
 }
 
 kotlin {

--- a/helm_deploy/hmpps-learner-records-api/values.yaml
+++ b/helm_deploy/hmpps-learner-records-api/values.yaml
@@ -44,6 +44,9 @@ generic-service:
       PFX_FILE_PASSWORD: "PFX_FILE_PASSWORD"
       UK_PRN: "UK_PRN"
       VENDOR_ID: "VENDOR_ID"
+      LRS_CONNECT_TIMEOUT: 20
+      LRS_WRITE_TIMEOUT: 20
+      LRS_READ_TIMEOUT: 20
 
   allowlist:
     groups:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/AppConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/AppConfig.kt
@@ -5,8 +5,9 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class AppConfig {
   fun ukprn(): String = System.getenv("UK_PRN") ?: throw IllegalArgumentException("UK_PRN environment variable not found.")
-
   fun password(): String = System.getenv("ORG_PASSWORD") ?: throw IllegalArgumentException("ORG_PASSWORD environment variable not found.")
-
   fun vendorId(): String = System.getenv("VENDOR_ID") ?: throw IllegalArgumentException("VENDOR_ID environment variable not found.")
+  fun lrsConnectTimeout(): Long = (System.getenv("LRS_CONNECT_TIMEOUT") ?: "20").toLong()
+  fun lrsWriteTimeout(): Long = (System.getenv("LRS_WRITE_TIMEOUT") ?: "20").toLong()
+  fun lrsReadTimeout(): Long = (System.getenv("LRS_READ_TIMEOUT") ?: "20").toLong()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.logging.LoggerUtil
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.exceptions.LRSException
+import java.net.SocketTimeoutException
 
 @RestControllerAdvice
 class HmppsBoldLrsExceptionHandler {
@@ -124,5 +125,21 @@ class HmppsBoldLrsExceptionHandler {
     )
     log.error(ex.message.orEmpty())
     return ResponseEntity(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+
+  @ExceptionHandler(SocketTimeoutException::class)
+  fun handleSocketTimeoutException(
+    ex: SocketTimeoutException,
+    request: WebRequest,
+  ): ResponseEntity<Any> {
+    val errorResponse = ErrorResponse(
+      status = HttpStatus.REQUEST_TIMEOUT,
+      errorCode = "Request Timeout",
+      userMessage = "A request to an upstream service timed out.",
+      developerMessage = "${ex.message}",
+      moreInfo = "A request timed out while waiting for a response from an upstream service.",
+    )
+    log.error("Socket Timeout Error: {}", ex)
+    return ResponseEntity(errorResponse, HttpStatus.REQUEST_TIMEOUT)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
@@ -4,6 +4,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
@@ -14,9 +15,8 @@ import java.util.concurrent.TimeUnit
 class HttpClientConfiguration(
   @Value("\${lrs.pfx-path}") val pfxFilePath: String,
   @Value("\${lrs.base-url}") val baseUrl: String,
-  @Value("\${lrs.connectTimeoutSeconds}") val connectTimeoutSeconds: Int,
-  @Value("\${lrs.writeTimeoutSeconds}") val writeTimeoutSeconds: Int,
-  @Value("\${lrs.readTimeoutSeconds}") val readTimeoutSeconds: Int,
+  @Autowired
+  private val appConfig: AppConfig,
 ) {
   fun buildSSLHttpClient(): OkHttpClient {
     log.info("Building HTTP client with SSL")
@@ -29,9 +29,9 @@ class HttpClientConfiguration(
       val trustManager = sslContextConfiguration.getTrustManager()
 
       val httpClientBuilder = OkHttpClient.Builder()
-        .connectTimeout(connectTimeoutSeconds.toLong(), TimeUnit.SECONDS)
-        .writeTimeout(writeTimeoutSeconds.toLong(), TimeUnit.SECONDS)
-        .readTimeout(readTimeoutSeconds.toLong(), TimeUnit.SECONDS)
+        .connectTimeout(appConfig.lrsConnectTimeout(), TimeUnit.SECONDS)
+        .writeTimeout(appConfig.lrsWriteTimeout(), TimeUnit.SECONDS)
+        .readTimeout(appConfig.lrsReadTimeout(), TimeUnit.SECONDS)
         .sslSocketFactory(sslContext.socketFactory, trustManager)
         .addInterceptor(loggingInterceptor)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HttpClientConfiguration.kt
@@ -8,11 +8,15 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
 import retrofit2.converter.jaxb.JaxbConverterFactory
+import java.util.concurrent.TimeUnit
 
 @Configuration
 class HttpClientConfiguration(
   @Value("\${lrs.pfx-path}") val pfxFilePath: String,
   @Value("\${lrs.base-url}") val baseUrl: String,
+  @Value("\${lrs.connectTimeoutSeconds}") val connectTimeoutSeconds: Int,
+  @Value("\${lrs.writeTimeoutSeconds}") val writeTimeoutSeconds: Int,
+  @Value("\${lrs.readTimeoutSeconds}") val readTimeoutSeconds: Int,
 ) {
   fun buildSSLHttpClient(): OkHttpClient {
     log.info("Building HTTP client with SSL")
@@ -25,6 +29,9 @@ class HttpClientConfiguration(
       val trustManager = sslContextConfiguration.getTrustManager()
 
       val httpClientBuilder = OkHttpClient.Builder()
+        .connectTimeout(connectTimeoutSeconds.toLong(), TimeUnit.SECONDS)
+        .writeTimeout(writeTimeoutSeconds.toLong(), TimeUnit.SECONDS)
+        .readTimeout(readTimeoutSeconds.toLong(), TimeUnit.SECONDS)
         .sslSocketFactory(sslContext.socketFactory, trustManager)
         .addInterceptor(loggingInterceptor)
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,6 @@ hmpps-auth:
 lrs:
   base-url: "https://cmp-ws.dev.lrs.education.gov.uk"
   pfx-path: "WebServiceClientCert.pfx"
+  connectTimeoutSeconds: 20
+  writeTimeoutSeconds: 20
+  readTimeoutSeconds: 20

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,3 @@ hmpps-auth:
 lrs:
   base-url: "https://cmp-ws.dev.lrs.education.gov.uk"
   pfx-path: "WebServiceClientCert.pfx"
-  connectTimeoutSeconds: 20
-  writeTimeoutSeconds: 20
-  readTimeoutSeconds: 20

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,3 +4,6 @@ hmpps-auth:
 lrs:
   base-url: "http://lrs-api:8080"
   pfx-path: "WebServiceClientCert.pfx"
+  connectTimeoutSeconds: 20
+  writeTimeoutSeconds: 20
+  readTimeoutSeconds: 20

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,3 @@ hmpps-auth:
 lrs:
   base-url: "http://lrs-api:8080"
   pfx-path: "WebServiceClientCert.pfx"
-  connectTimeoutSeconds: 20
-  writeTimeoutSeconds: 20
-  readTimeoutSeconds: 20

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,6 @@ management:
 lrs:
   base-url: ${lrs.base-url}
   pfx-path: ${lrs.pfx-path}
+  connectTimeoutSeconds: 20
+  writeTimeoutSeconds: 20
+  readTimeoutSeconds: 20

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,3 @@ management:
 lrs:
   base-url: ${lrs.base-url}
   pfx-path: ${lrs.pfx-path}
-  connectTimeoutSeconds: 20
-  writeTimeoutSeconds: 20
-  readTimeoutSeconds: 20

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandlerTest.kt
@@ -119,7 +119,7 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
       status = HttpStatus.REQUEST_TIMEOUT,
       errorCode = "Request Timeout",
       userMessage = "A request to an upstream service timed out.",
-      developerMessage = "Read timed out",
+      developerMessage = "dev message can vary",
       moreInfo = "A request timed out while waiting for a response from an upstream service.",
     )
 
@@ -134,7 +134,11 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
       .responseBody
 
     val actualResponseString = actualResponse?.toString(Charsets.UTF_8)
-    assertThat(actualResponseString).isEqualTo(gson.toJson(expectedResponse))
+
+    val actualResponseObject = gson.fromJson(actualResponseString, HmppsBoldLrsExceptionHandler.ErrorResponse::class.java)
+
+    assertThat(actualResponseObject.copy(developerMessage = "dev message can vary"))
+      .isEqualTo(expectedResponse)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/HmppsBoldLrsExceptionHandlerTest.kt
@@ -114,7 +114,7 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should catch timeout exceptions (SocketTimeoutException) and return Gateway Timeout`() {
+  fun `should catch timeout exceptions (SocketTimeoutException) and return Request Timeout`() {
     val expectedResponse = HmppsBoldLrsExceptionHandler.ErrorResponse(
       status = HttpStatus.REQUEST_TIMEOUT,
       errorCode = "Request Timeout",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/TestExceptionResource.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/TestExceptionResource.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.config
 
 import com.google.gson.JsonParseException
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.core.MethodParameter
 import org.springframework.http.HttpInputMessage
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -12,11 +16,15 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.lrsapi.response.exceptions.LRSException
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 // Simply to assist in testing HmppsBoldLrsExceptionHandler, the endpoints are only visible to tests.
 
 @RestController
-class TestExceptionResource {
+class TestExceptionResource(
+  @Autowired
+  private val httpClientConfiguration: HttpClientConfiguration,
+) {
 
   @PostMapping("/test/validation")
   fun triggerValidationException(): Nothing = throw MethodArgumentNotValidException(
@@ -41,4 +49,18 @@ class TestExceptionResource {
 
   @PostMapping("/test/generic-exception")
   fun triggerGenericException(): Nothing = throw Exception()
+
+  @PostMapping("/test/okhttp-timeout")
+  fun triggerOkhttpTimeout(): String? {
+    val mockTimeoutServer = MockWebServer()
+    mockTimeoutServer.enqueue(MockResponse().setBody("Delayed response").setBodyDelay(15, TimeUnit.SECONDS))
+    mockTimeoutServer.start()
+
+    val request = Request.Builder()
+      .url(mockTimeoutServer.url("/timeout")) // Point to the MockWebServer URL
+      .build()
+
+    val response = httpClientConfiguration.buildSSLHttpClient().newCall(request).execute()
+    return response.body?.string()
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/OpenApiDocsTest.kt
@@ -104,8 +104,8 @@ class OpenApiDocsTest : IntegrationTestBase() {
       .expectBody()
       .jsonPath("$.paths[*][*][?(!@.security)]")
       .value<List<Any>> { list ->
-        // Assert that the list has only 5 items since there are 5 test endpoints
-        assertThat(list).hasSize(5)
+        // Assert that the list has only 6 items since there are 6 test endpoints
+        assertThat(list).hasSize(6)
       }
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,3 @@ hmpps-auth:
 lrs:
   base-url: "http://localhost:8082"
   pfx-path: "WebServiceClientCert.pfx"
-  connectTimeoutSeconds: 3
-  writeTimeoutSeconds: 3
-  readTimeoutSeconds: 3

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,6 @@ hmpps-auth:
 lrs:
   base-url: "http://localhost:8082"
   pfx-path: "WebServiceClientCert.pfx"
-  connectTimeoutSeconds: 1
-  writeTimeoutSeconds: 1
-  readTimeoutSeconds: 1
+  connectTimeoutSeconds: 3
+  writeTimeoutSeconds: 3
+  readTimeoutSeconds: 3

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,6 @@ hmpps-auth:
 lrs:
   base-url: "http://localhost:8082"
   pfx-path: "WebServiceClientCert.pfx"
+  connectTimeoutSeconds: 1
+  writeTimeoutSeconds: 1
+  readTimeoutSeconds: 1


### PR DESCRIPTION
Tested also. Currently allows 20 secs for each possible timeout part of the request, totalling 1 min.