### PR TITLE
Make Mismatch Logic Case Insensitive

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
@@ -72,7 +72,7 @@ class LearnersService(
         val requestValue = requestFieldNames[fieldName]?.call(request)?.toString()
         val learnerValue = learnerFieldNames[fieldName]?.call(learner)?.toString()
         val neitherAreNull = (learnerValue != null && requestValue != null)
-        if (requestValue.orEmpty().lowercase() != learnerValue.orEmpty().lowercase() && neitherAreNull) {
+        if (requestValue.orEmpty().trim().lowercase() != learnerValue.orEmpty().trim().lowercase() && neitherAreNull) {
           mismatchedFields.computeIfAbsent(fieldName) { mutableListOf() }
             .add(learnerValue.orEmpty())
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
@@ -71,10 +71,10 @@ class LearnersService(
       sharedFieldNames.forEach { fieldName ->
         val requestValue = requestFieldNames[fieldName]?.call(request)?.toString()
         val learnerValue = learnerFieldNames[fieldName]?.call(learner)?.toString()
-
-        if (requestValue != learnerValue && learnerValue != null && requestValue != null) {
+        val neitherAreNull = (learnerValue != null && requestValue != null)
+        if (requestValue.orEmpty().lowercase() != learnerValue.orEmpty().lowercase() && neitherAreNull) {
           mismatchedFields.computeIfAbsent(fieldName) { mutableListOf() }
-            .add(learnerValue)
+            .add(learnerValue.orEmpty())
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnersResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnersResourceIntTest.kt
@@ -202,7 +202,6 @@ class LearnersResourceIntTest : IntegrationTestBase() {
           responseType = LRSResponseType.POSSIBLE_MATCH,
           mismatchedFields = mutableMapOf(
             ("dateOfBirth" to mutableListOf("1995-06-28", "1995-06-28")),
-//            ("gender" to mutableListOf("2", "2")),
             ("lastKnownPostCode" to mutableListOf("SO40 4JX")),
           ),
           matchedLearners = expectedPossibleMatchLearners,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersServiceTest.kt
@@ -160,9 +160,9 @@ class LearnersServiceTest {
       dateOfBirth = LocalDate.of(1980, 1, 1),
       gender = Gender.MALE,
       lastKnownPostCode = "ABCDEF",
-      previousFamilyName = "Test",
-      schoolAtAge16 = "Test High School",
-      placeOfBirth = "Some place",
+      previousFamilyName = "TeSt",
+      schoolAtAge16 = "Test High SchOol",
+      placeOfBirth = "Some plAce",
       emailAddress = "test_email@test.com",
     )
 


### PR DESCRIPTION
Checks in lowercase.
Trims leading and trailing spaces from the checks, too.