### PR TITLE
Update confirm match request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/ConfirmMatchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/ConfirmMatchRequest.kt
@@ -16,7 +16,7 @@ class ConfirmMatchRequest(
 
   val matchType: MatchType,
 
-  val countOfReturnedUlns: String,
+  val countOfReturnedUlns: String? = null,
 
 ) {
   fun asMatchEntity(nomisId: String): MatchEntity = MatchEntity(
@@ -26,6 +26,6 @@ class ConfirmMatchRequest(
     givenName.orEmpty(),
     familyName.orEmpty(),
     matchType.toString(),
-    countOfReturnedUlns,
+    countOfReturnedUlns.orEmpty(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/ConfirmMatchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/ConfirmMatchRequest.kt
@@ -6,26 +6,26 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.db.MatchEntity
 class ConfirmMatchRequest(
 
   @field:Pattern(regexp = "^[0-9]{1,10}\$")
-  val matchingUln: String,
+  val matchingUln: String? = null,
 
   @field:Pattern(regexp = "^[A-Za-z' ,.-]{3,35}$")
-  val givenName: String,
+  val givenName: String? = null,
 
   @field:Pattern(regexp = "^[A-Za-z' ,.-]{3,35}$")
-  val familyName: String,
+  val familyName: String? = null,
 
-  val matchType: MatchType? = null,
+  val matchType: MatchType,
 
-  val countOfMatchedUlns: String? = null,
+  val countOfMatchedUlns: String,
 
 ) {
   fun asMatchEntity(nomisId: String): MatchEntity = MatchEntity(
     null,
     nomisId,
-    matchingUln,
-    givenName,
-    familyName,
+    matchingUln.orEmpty(),
+    givenName.orEmpty(),
+    familyName.orEmpty(),
     matchType.toString(),
-    countOfMatchedUlns.orEmpty(),
+    countOfMatchedUlns,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/MatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/MatchServiceTest.kt
@@ -10,11 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.db.MatchEntity
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.ConfirmMatchRequest
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.Gender
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.MatchType
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.repository.MatchRepository
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.utils.toISOFormat
-import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
 class MatchServiceTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/MatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/MatchServiceTest.kt
@@ -22,8 +22,6 @@ class MatchServiceTest {
   private val matchedUln = "a1234"
   private val givenName = "John"
   private val familyName = "Smith"
-  private val dateOfBirth = LocalDate.now().toISOFormat()
-  private val gender = Gender.MALE.name
 
   private lateinit var mockMatchRepository: MatchRepository
   private lateinit var matchService: MatchService


### PR DESCRIPTION
- `matchingULN`, `givenName`, and `familyName` can be empty in the ConfirmMatchRequest if we want to save the event that none of the ULNs returned from LRS are a suitable match or if there is no match from LRS.  
- We want to always save the `matchType` when someone is sending a ConfirmMatchRequest. 
- Removing date of birth and gender values from a test as they aren't used.