### PR TITLE
Correcting read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ The match will be saved as a `MatchEntity` in the database.
   "matchingUln": "1234567890",
   "givenName": "John",
   "familyName": "Smith",
-  "matchType": "POSSIBLE_MATCH",
-  "countOfReturnedULNs": "2"
+  "matchType": "Possible match",
+  "countOfReturnedUlns": "2"
 }
 </pre>
 </details>
@@ -287,8 +287,8 @@ The match will be saved as a `MatchEntity` in the database.
 <br>
 <pre>
 {
-  "matchType": "NO_MATCH_RETURNED_FROM_LRS",
-  "countOfReturnedULNs": "0"
+  "matchType": "No match returned from LRS",
+  "countOfReturnedUlns": "0"
 }
 </pre>
 </details>
@@ -296,43 +296,6 @@ The match will be saved as a `MatchEntity` in the database.
 Response codes:
 * 201 - Created
 * 400 - Bad Request, malformed json body
-* 401 - Unauthorised
-* 403 - Forbidden
-* 500 - Likely that the database is unreachable
-
-### `POST:/match/:nomisId`
-This endpoint is to confirm a match between a learner's NOMIS ID and ULN.
-The givenName and familyName should be as per the LRS data for a match.
-The match will be saved as a `MatchEntity` in the database.
-
-<details>
-<summary>Example request body for a match:</summary>
-<br>
-<pre>
-{
-  "matchingUln": "1234567890",
-  "givenName": "John",
-  "familyName": "Smith",
-  "matchType": "POSSIBLE_MATCH",
-  "countOfReturnedULNs": "2"
-}
-</pre>
-</details>
-
-<details>
-<summary>Example request body for a no match:</summary>
-<br>
-<pre>
-{
-  "matchType": "NO_MATCH_SELECTED",
-  "countOfReturnedULNs": "6"
-}
-</pre>
-</details>
-
-Response codes:
-* 201 - Created
-* 400 - Bad Request, malformed ULN or json body
 * 401 - Unauthorised
 * 403 - Forbidden
 * 500 - Likely that the database is unreachable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/MatchType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/MatchType.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonValue
 
 enum class MatchType(val description: String) {
-  NO_MATCH_RETURNED_FROM_LRS("No match returned from LRS"),
-  EXACT_MATCH("Exact match"),
-  POSSIBLE_MATCH("Possible match"),
-  LINKED_LEARNER_MATCH("Linked learner match"),
-  TOO_MANY_RESULTS("Too many results"),
+  NO_MATCH_RETURNED_FROM_LRS("No Match"),
+  EXACT_MATCH("Exact Match"),
+  POSSIBLE_MATCH("Possible Match"),
+  LINKED_LEARNER_MATCH("Linked Learner Match"),
+  TOO_MANY_RESULTS("Too Many Matches"),
   ;
 
   @JsonValue

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/MatchType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/MatchType.kt
@@ -7,7 +7,7 @@ enum class MatchType(val description: String) {
   NO_MATCH_RETURNED_FROM_LRS("No match returned from LRS"),
   EXACT_MATCH("Exact match"),
   POSSIBLE_MATCH("Possible match"),
-  LINKED_LEARNER_MATCH("linked learner match"),
+  LINKED_LEARNER_MATCH("Linked learner match"),
   TOO_MANY_RESULTS("Too many results"),
   ;
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/MatchConfirmApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/MatchConfirmApi.kt
@@ -37,34 +37,10 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
                 "matchingUln": "1026893096",
                 "givenName": "Darcie",
                 "familyName": "Tucker",
-                "matchType": "EXACT_MATCH",
+                "matchType": "Exact Match",
                 "countOfReturnedUlns": "1"
               }
-              """,
-          ),
-          ExampleObject(
-            name = "Confirm no match selected Request",
-            value = """
-              {
-                "matchingUln": "",
-                "givenName": "",
-                "familyName": "",
-                "matchType": "NO_MATCH_SELECTED",
-                "countOfReturnedUlns": "2"
-              }
-              """,
-          ),
-          ExampleObject(
-            name = "Confirm no match found Request",
-            value = """
-              {
-                "matchingUln": "",
-                "givenName": "",
-                "familyName": "",
-                "matchType": "NO_MATCH_RETURNED_FROM_LRS",
-                "countOfReturnedUlns": "0"
-              }
-              """,
+              """
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/MatchConfirmApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/MatchConfirmApi.kt
@@ -40,7 +40,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
                 "matchType": "Exact Match",
                 "countOfReturnedUlns": "1"
               }
-              """
+              """,
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/NoMatchConfirmApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/openapi/NoMatchConfirmApi.kt
@@ -34,7 +34,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
             name = "Confirm no match Request",
             value = """
               {
-                "matchType": "NO_MATCH_RETURNED_FROM_LRS",
+                "matchType": "No Match",
                 "countOfReturnedUlns": "0"
               }
               """,


### PR DESCRIPTION
- Duplication of an endpoint in readme.
- Updating the example request body for the POST match endpoints.
- Updating MatchType description values to align with LRSResponseType.