### PR TITLE
[ESWE-1462] Upgrade dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.2"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.1.1"
   kotlin("plugin.spring") version "2.2.20"
 }
 


### PR DESCRIPTION
- plugin `gradle-spring-boot` to `9.1.1` (was `9.0.2`)