### PR TITLE
ESWE-1722: Spring Boot 4 upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,17 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.3.0"
-  kotlin("plugin.spring") version "2.2.21"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.0.4"
+  kotlin("plugin.spring") version "2.3.10"
 }
 
 configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
-ext["netty.version"] = "4.1.130.Final"
-
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.8.1") {
-    implementation("org.apache.commons:commons-compress:1.27.1")
-  }
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.0.1")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
+  implementation("org.springframework.boot:spring-boot-starter-flyway")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
   implementation("com.squareup.retrofit2:retrofit:2.11.0")
   implementation("com.squareup.retrofit2:converter-jaxb:2.11.0")
   implementation("com.google.code.gson:gson")
@@ -22,7 +19,7 @@ dependencies {
   implementation("javax.xml.bind:jaxb-api:2.3.1")
   implementation("org.glassfish.jaxb:jaxb-runtime:2.3.5")
   implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.6.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.0.1")
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
@@ -30,12 +27,13 @@ dependencies {
   implementation("com.h2database:h2")
   testImplementation("com.h2database:h2")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:1.8.1")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.0.1")
+  testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.wiremock:wiremock-standalone:3.13.0")
-  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.29") {
+  testImplementation("io.swagger.parser.v3:swagger-parser:2.1.38") {
     exclude(group = "io.swagger.core.v3")
   }
-  testImplementation("org.testcontainers:localstack")
+  testImplementation("org.testcontainers:testcontainers-localstack")
   testImplementation("org.awaitility:awaitility-kotlin")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
   testImplementation("com.squareup.okhttp3:mockwebserver:4.10.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,10 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.0.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.0.2")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-flyway")
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
   implementation("com.squareup.retrofit2:retrofit:2.11.0")
   implementation("com.squareup.retrofit2:converter-jaxb:2.11.0")
   implementation("com.google.code.gson:gson")
@@ -27,7 +27,7 @@ dependencies {
   implementation("com.h2database:h2")
   testImplementation("com.h2database:h2")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.0.1")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.0.2")
   testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.wiremock:wiremock-standalone:3.13.0")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.38") {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/JacksonConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/JacksonConfig.kt
@@ -1,20 +1,17 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.config
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
 
 @Configuration
 class JacksonConfig {
   @Bean
-  fun objectMapper(): ObjectMapper {
-    val objectMapper = Jackson2ObjectMapperBuilder.json().build<ObjectMapper>()
-    objectMapper.registerModule(JavaTimeModule())
-    objectMapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-    return objectMapper
-  }
+  fun jsonMapper(): JsonMapper = JsonMapper.builder()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+    .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+    .changeDefaultPropertyInclusion { it.withContentInclusion(JsonInclude.Include.NON_NULL) }
+    .build()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/LearnersRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/LearnersRequest.kt
@@ -44,7 +44,7 @@ data class LearnersRequest(
   fun extractFromRequest(): LearnersLRSRequest = LearnersLRSRequest(
     givenName = givenName,
     familyName = familyName,
-    dateOfBirth = dateOfBirth?.let { LocalDate.parse(it) },
+    dateOfBirth = LocalDate.parse(dateOfBirth),
     gender = gender.code,
     lastKnownPostCode = lastKnownPostCode,
     previousFamilyName = previousFamilyName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnerEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnerEventsService.kt
@@ -16,9 +16,9 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.response.LearnerEve
 
 @Service
 class LearnerEventsService(
-  @Autowired
+  @param:Autowired
   private val httpClientConfiguration: HttpClientConfiguration,
-  @Autowired
+  @param:Autowired
   private val lrsConfiguration: LRSConfiguration,
 ) : BaseService() {
   private val logger: Logger = LoggerUtil.getLogger<LearnerEventsService>()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/service/LearnersService.kt
@@ -18,9 +18,9 @@ import kotlin.reflect.full.declaredMemberProperties
 
 @Service
 class LearnersService(
-  @Autowired
+  @param:Autowired
   private val httpClientConfiguration: HttpClientConfiguration,
-  @Autowired
+  @param:Autowired
   private val lrsConfiguration: LRSConfiguration,
 ) : BaseService() {
 
@@ -67,7 +67,7 @@ class LearnersService(
         val neitherAreNull = (learnerValue != null && requestValue != null)
         if (requestValue.orEmpty().trim().lowercase() != learnerValue.orEmpty().trim().lowercase() && neitherAreNull) {
           mismatchedFields.computeIfAbsent(fieldName) { mutableListOf() }
-            .add(learnerValue.orEmpty())
+            .add(learnerValue)
         }
       }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,9 @@ info.app:
 spring:
   application:
     name: hmpps-learner-records-api
-  codec:
-    max-in-memory-size: 10MB
+  http:
+    codecs:
+      max-in-memory-size: 10MB
 
   security:
     oauth2:
@@ -29,6 +30,9 @@ spring:
 
   flyway:
     enabled: true
+  web:
+    error:
+      include-message: always
 
 server:
   port: 8080
@@ -41,8 +45,6 @@ server:
       protocol-header: x-forwarded-proto
       internal-proxies: 10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1|100\.6[4-9]\.\d{1,3}\.\d{1,3}|100\.[7-9][0-9]{1}\.\d{1,3}\.\d{1,3}|100\.1[0-1][0-9]{1}\.\d{1,3}\.\d{1,3}|100\.12[0-7]\.\d{1,3}\.\d{1,3}
   shutdown: graceful
-  error:
-    include-message: always
 
 management:
   endpoints:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/TestExceptionResource.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/config/TestExceptionResource.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 
 @RestController
 class TestExceptionResource(
-  @Autowired
+  @field:Autowired
   private val httpClientConfiguration: HttpClientConfiguration,
 ) {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/db/MockMatchRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/db/MockMatchRepository.kt
@@ -30,19 +30,19 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> save(entity: S): S {
+  override fun <S : MatchEntity> save(entity: S): S {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> saveAll(entities: MutableIterable<S>): MutableList<S> {
+  override fun <S : MatchEntity> saveAll(entities: MutableIterable<S>): MutableList<S> {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> findAll(example: Example<S>): MutableList<S> {
+  override fun <S : MatchEntity> findAll(example: Example<S>): MutableList<S> {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> findAll(example: Example<S>, sort: Sort): MutableList<S> {
+  override fun <S : MatchEntity> findAll(example: Example<S>, sort: Sort): MutableList<S> {
     TODO("Not yet implemented")
   }
 
@@ -58,7 +58,7 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> findAll(example: Example<S>, pageable: Pageable): Page<S> {
+  override fun <S : MatchEntity> findAll(example: Example<S>, pageable: Pageable): Page<S> {
     TODO("Not yet implemented")
   }
 
@@ -70,7 +70,7 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> count(example: Example<S>): Long {
+  override fun <S : MatchEntity> count(example: Example<S>): Long {
     TODO("Not yet implemented")
   }
 
@@ -90,15 +90,15 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> findOne(example: Example<S>): Optional<S> {
+  override fun <S : MatchEntity> findOne(example: Example<S>): Optional<S> {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> exists(example: Example<S>): Boolean {
+  override fun <S : MatchEntity> exists(example: Example<S>): Boolean {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?, R : Any?> findBy(
+  override fun <S : MatchEntity, R : Any?> findBy(
     example: Example<S>,
     queryFunction: Function<FluentQuery.FetchableFluentQuery<S>, R>,
   ): R {
@@ -109,11 +109,11 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> saveAndFlush(entity: S): S {
+  override fun <S : MatchEntity> saveAndFlush(entity: S): S {
     TODO("Not yet implemented")
   }
 
-  override fun <S : MatchEntity?> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> {
+  override fun <S : MatchEntity> saveAllAndFlush(entities: MutableIterable<S>): MutableList<S> {
     TODO("Not yet implemented")
   }
 
@@ -133,10 +133,12 @@ class MockMatchRepository(val entities: List<MatchEntity>) : MatchRepository {
     TODO("Not yet implemented")
   }
 
+  @Deprecated("Deprecated in Java")
   override fun getById(id: Long): MatchEntity {
     TODO("Not yet implemented")
   }
 
+  @Deprecated("Deprecated in Java")
   override fun getOne(id: Long): MatchEntity {
     TODO("Not yet implemented")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/IntegrationTestBase.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -12,6 +13,7 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.LocalStackCont
 import uk.gov.justice.hmpps.test.kotlin.auth.JwtAuthorisationHelper
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureWebTestClient
 @ActiveProfiles("test")
 abstract class IntegrationTestBase {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnerEventsResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnerEventsResourceIntTest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HmppsBoldLrsExceptionHandler
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles.ROLE_LEARNERS_UI
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.LRSApiExtension.Companion.lrsApiMock
@@ -22,7 +22,7 @@ import uk.gov.justice.hmpps.sqs.MissingQueueException
 class LearnerEventsResourceIntTest : IntegrationTestBase() {
 
   @Autowired
-  lateinit var objectMapper: ObjectMapper
+  lateinit var jsonMapper: JsonMapper
 
   @Autowired
   protected lateinit var hmppsQueueService: HmppsQueueService
@@ -44,7 +44,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
     fun `should return 500 with an appropriate error response if LRS returns an InternalServerError`() {
       lrsApiMock.stubPostServerError()
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -94,7 +94,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
         ),
       )
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -148,7 +148,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
         ),
       )
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -179,7 +179,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
         emptyList(),
       )
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -210,7 +210,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
         emptyList(),
       )
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -233,7 +233,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
     fun `should return 400 with an appropriate error response if X-Username header is missing`() {
       lrsApiMock.stubLearningEventsExactMatchFull()
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -261,7 +261,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
       extendedRequestBody["uln"] = "1174112637"
       extendedRequestBody["unknownValue"] = "1234"
 
-      val actualResponse = objectMapper.readValue(
+      val actualResponse = jsonMapper.readValue(
         webTestClient.post()
           .uri("/learner-events")
           .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_UI)))
@@ -278,7 +278,7 @@ class LearnerEventsResourceIntTest : IntegrationTestBase() {
       )
 
       val actualResponseString = actualResponse?.toString()
-      assertThat(actualResponseString).contains("Unrecognized field \"unknownValue\"")
+      assertThat(actualResponseString).contains("Unrecognized property \"unknownValue\"")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnersResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LearnersResourceIntTest.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HmppsBoldLrsExceptionHandler
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles.ROLE_LEARNERS_UI
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.wiremock.LRSApiExtension.Companion.lrsApiMock
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.response.LearnersRe
 class LearnersResourceIntTest : IntegrationTestBase() {
 
   @Autowired
-  protected lateinit var objectMapper: ObjectMapper
+  protected lateinit var jsonMapper: JsonMapper
 
   @Nested
   @DisplayName("POST /learners")
@@ -53,7 +53,7 @@ class LearnersResourceIntTest : IntegrationTestBase() {
 
       return when (expectedStatus) {
         200 ->
-          objectMapper.readValue(
+          jsonMapper.readValue(
             executedRequest
               .isOk
               .expectBody()
@@ -63,7 +63,7 @@ class LearnersResourceIntTest : IntegrationTestBase() {
           )
 
         500 ->
-          objectMapper.readValue(
+          jsonMapper.readValue(
             executedRequest
               .is5xxServerError
               .expectBody()
@@ -326,7 +326,7 @@ class LearnersResourceIntTest : IntegrationTestBase() {
         .responseBody
 
       val actualResponseString = executedRequest?.toString(Charsets.UTF_8)
-      assertThat(actualResponseString).contains("Unrecognized field \\\"unknownValue\\\"")
+      assertThat(actualResponseString).contains("Unrecognized property \\\"unknownValue\\\"")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/LocalStackContainer.kt
@@ -2,9 +2,9 @@ package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 
 import org.slf4j.LoggerFactory
 import org.springframework.test.context.DynamicPropertyRegistry
-import org.testcontainers.containers.localstack.LocalStackContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import java.io.IOException
 import java.net.ServerSocket
@@ -14,7 +14,7 @@ object LocalStackContainer {
   val instance by lazy { startLocalstackIfNotRunning() }
 
   fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) {
-    registry.add("hmpps.sqs.localstackUrl") { localStackContainer.getEndpointOverride(LocalStackContainer.Service.SNS) }
+    registry.add("hmpps.sqs.localstackUrl") { localStackContainer.endpoint }
     registry.add("hmpps.sqs.region") { localStackContainer.region }
   }
 
@@ -28,7 +28,7 @@ object LocalStackContainer {
     return LocalStackContainer(
       DockerImageName.parse("localstack/localstack").withTag("3"),
     ).apply {
-      withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
+      withServices("sns", "sqs")
       withEnv("DEFAULT_REGION", "eu-west-2")
       waitingFor(
         Wait.forLogMessage(".*Ready.*", 1),
@@ -41,7 +41,7 @@ object LocalStackContainer {
   private fun localstackIsRunning(): Boolean = try {
     val serverSocket = ServerSocket(4566)
     serverSocket.localPort == 0
-  } catch (e: IOException) {
+  } catch (_: IOException) {
     true
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/MatchResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/MatchResourceIntTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -20,6 +19,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import tools.jackson.databind.json.JsonMapper
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.AuditEvent.MATCH_LE
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HmppsBoldLrsExceptionHandler
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles.ROLE_LEARNERS_RO
@@ -56,7 +56,7 @@ class MockitoSpyConfig {
 class MatchResourceIntTest : IntegrationTestBase() {
 
   @Autowired
-  protected lateinit var objectMapper: ObjectMapper
+  protected lateinit var jsonMapper: JsonMapper
 
   @Autowired
   lateinit var matchRepository: MatchRepository
@@ -95,7 +95,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus()
 
-      val checkMatchResponse = objectMapper.readValue(
+      val checkMatchResponse = jsonMapper.readValue(
         executedRequest
           .isEqualTo(expectedResponseStatus)
           .expectBody()
@@ -209,7 +209,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
   @Test
   fun `POST to confirm match should return 400 if ULN is malformed`() {
     val (nomisId, uln) = arrayOf("A1417AE", "1234567890abcdef")
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       postMatch(nomisId, uln, 400).expectBody().returnResult().responseBody,
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
@@ -230,7 +230,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
   fun `POST to confirm match should return 500 if match service fails to save`() {
     val (nomisId, uln) = arrayOf("A1417AE", "1234567890")
     doThrow(RuntimeException("Database error")).`when`(matchService).saveMatch(any(), any())
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       postMatch(nomisId, uln, 500).expectBody().returnResult().responseBody,
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
@@ -283,7 +283,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
       .returnResult()
       .responseBody
 
-    val receivedEvent = objectMapper.readValue(
+    val receivedEvent = jsonMapper.readValue(
       auditSqsClient.receiveMessage(
         ReceiveMessageRequest.builder().queueUrl(auditQueueUrl).build(),
       ).get().messages()[0].body(),
@@ -347,7 +347,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
       ),
     )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.get()
         .uri("/match/{nomisId}/learner-events", "123456")
         .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
@@ -374,7 +374,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
       moreInfo = "Individual with this NomisId has not been matched to a ULN yet",
     )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.get()
         .uri("/match/{nomisId}/learner-events", "123456")
         .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
@@ -414,7 +414,7 @@ class MatchResourceIntTest : IntegrationTestBase() {
       ),
     )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.get()
         .uri("/match/{nomisId}/learner-events", "456789")
         .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/ValidationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/ValidationTest.kt
@@ -1,21 +1,24 @@
-package uk.gov.justice.digital.hmpps.learnerrecordsapi.config
+package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles.ROLE_LEARNERS_RO
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.IntegrationTestBase
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HmppsBoldLrsExceptionHandler
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.Gender
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest
 
-// Tests that HmppsBoldLrsExceptionHandler works as expected when actually calling our endpoints.
-
+/**
+ * Tests that HmppsBoldLrsExceptionHandler works as expected when actually calling our endpoints.
+ */
 class ValidationTest : IntegrationTestBase() {
 
   @Autowired
-  lateinit var objectMapper: ObjectMapper
+  lateinit var jsonMapper: JsonMapper
 
   @Test
   fun `learners endpoint should return validation errors when user postcode is invalid`() {
@@ -28,7 +31,7 @@ class ValidationTest : IntegrationTestBase() {
     )
 
     val findLearnerByDemographicsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest(
+      LearnersRequest(
         "Sample",
         "Testname",
         "2024-01-01",
@@ -40,10 +43,10 @@ class ValidationTest : IntegrationTestBase() {
         "test_email@test.com",
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(findLearnerByDemographicsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -56,7 +59,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -70,7 +73,7 @@ class ValidationTest : IntegrationTestBase() {
     )
 
     val findLearnerByDemographicsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest(
+      LearnersRequest(
         "SampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSample",
         "Testname",
         "2024-01-01",
@@ -82,10 +85,10 @@ class ValidationTest : IntegrationTestBase() {
         "test_email@test.com",
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(findLearnerByDemographicsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -98,7 +101,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -112,7 +115,7 @@ class ValidationTest : IntegrationTestBase() {
     )
 
     val learnerEventsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest(
+      LearnerEventsRequest(
         "SampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSampleSample",
         "Testname",
         "1234567890",
@@ -120,10 +123,10 @@ class ValidationTest : IntegrationTestBase() {
         Gender.MALE,
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learner-events")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(learnerEventsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -136,7 +139,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -149,7 +152,7 @@ class ValidationTest : IntegrationTestBase() {
       "Validation(s) failed for [familyName] with reason(s): [must match \"^[A-Za-z' ,.-]{3,35}\$\"]",
     )
     val findLearnerByDemographicsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest(
+      LearnersRequest(
         "Sample",
         "TestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestname",
         "2024-01-01",
@@ -161,10 +164,10 @@ class ValidationTest : IntegrationTestBase() {
         "test_email@test.com",
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(findLearnerByDemographicsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -177,7 +180,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -190,7 +193,7 @@ class ValidationTest : IntegrationTestBase() {
       "Validation(s) failed for [previousFamilyName] with reason(s): [must match \"^[A-Za-z' ,.-]{3,35}\$\"]",
     )
     val findLearnerByDemographicsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest(
+      LearnersRequest(
         "Sample",
         "Testname",
         "2024-01-01",
@@ -202,10 +205,10 @@ class ValidationTest : IntegrationTestBase() {
         "test_email@test.com",
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(findLearnerByDemographicsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -218,7 +221,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -231,7 +234,7 @@ class ValidationTest : IntegrationTestBase() {
       "Validation(s) failed for [emailAddress] with reason(s): [must match \"^[A-Za-z0-9._'%+-]{1,64}@(?:(?=[A-Za-z0-9-]{1,63}\\.)[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*\\.){1,8}[A-Za-z]{2,63}\$\"]",
     )
     val findLearnerByDemographicsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest(
+      LearnersRequest(
         "Sample",
         "Testname",
         "2024-01-01",
@@ -243,10 +246,10 @@ class ValidationTest : IntegrationTestBase() {
         "test_email@@test.com",
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(findLearnerByDemographicsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -259,7 +262,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -272,7 +275,7 @@ class ValidationTest : IntegrationTestBase() {
       "Validation(s) failed for [familyName] with reason(s): [must match \"^[A-Za-z' ,.-]{3,35}\$\"]",
     )
     val learnerEventsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest(
+      LearnerEventsRequest(
         "Sample",
         "TestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestnameTestname",
         "1234567890",
@@ -280,10 +283,10 @@ class ValidationTest : IntegrationTestBase() {
         Gender.MALE,
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learner-events")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(learnerEventsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -296,7 +299,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -309,7 +312,7 @@ class ValidationTest : IntegrationTestBase() {
       "Validation(s) failed for [uln] with reason(s): [must match \"^[0-9]{1,10}\$\"]",
     )
     val learnerEventsRequest =
-      uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest(
+      LearnerEventsRequest(
         "Sample",
         "Testname",
         "12345678901234567890",
@@ -317,10 +320,10 @@ class ValidationTest : IntegrationTestBase() {
         Gender.MALE,
       )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learner-events")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .bodyValue(learnerEventsRequest)
         .accept(MediaType.parseMediaType("application/json"))
@@ -333,7 +336,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -354,10 +357,10 @@ class ValidationTest : IntegrationTestBase() {
         "gender": "TESTINGENUM",
         "postcode": "CV49EE"
         }"""
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(findLearnerByDemographicsRequest)
@@ -370,7 +373,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -391,10 +394,10 @@ class ValidationTest : IntegrationTestBase() {
         "gender": "TESTINGENUM",
         "uln": "1234567890"
         }"""
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learner-events")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser").contentType(MediaType.APPLICATION_JSON)
         .bodyValue(findLearnerByDemographicsRequest)
         .exchange()
@@ -406,7 +409,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -415,10 +418,9 @@ class ValidationTest : IntegrationTestBase() {
       HttpStatus.BAD_REQUEST,
       "Unreadable HTTP message",
       "Unreadable HTTP message",
-      "JSON parse error: Instantiation of " +
-        "[simple type, class uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest] " +
-        "value failed for JSON property givenName due to missing (therefore NULL) value " +
-        "for creator parameter givenName which is a non-nullable type",
+      """
+        JSON parse error: Cannot construct instance of `uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest`, problem: Parameter specified as non-null is null: method uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnersRequest.<init>, parameter givenName
+      """.trimIndent(),
       "Unreadable HTTP message",
     )
 
@@ -431,10 +433,10 @@ class ValidationTest : IntegrationTestBase() {
       }
     """
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learners")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(requestJsonWithoutGivenName)
@@ -448,7 +450,7 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -457,11 +459,11 @@ class ValidationTest : IntegrationTestBase() {
       HttpStatus.BAD_REQUEST,
       "Unreadable HTTP message",
       "Unreadable HTTP message",
-      "JSON parse error: Instantiation of " +
-        "[simple type, class uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest] " +
-        "value failed for JSON property givenName due to missing (therefore NULL) value " +
-        "for creator parameter givenName which is a non-nullable type",
+      """
+        JSON parse error: Cannot construct instance of `uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest`, problem: Parameter specified as non-null is null: method uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request.LearnerEventsRequest.<init>, parameter givenName
+      """.trimIndent(),
       "Unreadable HTTP message",
+      //
     )
 
     val requestJsonWithoutGivenName = """
@@ -473,10 +475,10 @@ class ValidationTest : IntegrationTestBase() {
       }
     """
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/learner-events")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .header("X-Username", "TestUser")
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(requestJsonWithoutGivenName)
@@ -490,6 +492,6 @@ class ValidationTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/config/HmppsBoldLrsExceptionHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/integration/config/HmppsBoldLrsExceptionHandlerTest.kt
@@ -1,12 +1,13 @@
-package uk.gov.justice.digital.hmpps.learnerrecordsapi.config
+package uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles.ROLE_LEARNERS_RO
+import tools.jackson.databind.json.JsonMapper
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.HmppsBoldLrsExceptionHandler
+import uk.gov.justice.digital.hmpps.learnerrecordsapi.config.Roles
 import uk.gov.justice.digital.hmpps.learnerrecordsapi.integration.IntegrationTestBase
 import java.time.Duration
 
@@ -16,7 +17,7 @@ import java.time.Duration
 class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
 
   @Autowired
-  lateinit var objectMapper: ObjectMapper
+  lateinit var jsonMapper: JsonMapper
 
   @BeforeEach
   fun setUp() {
@@ -30,10 +31,10 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
     expectedResponse: HmppsBoldLrsExceptionHandler.ErrorResponse,
     expectedStatus: HttpStatus,
   ) {
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri(uri)
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .exchange()
         .expectStatus()
         .isEqualTo(expectedStatus)
@@ -43,7 +44,7 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse).isEqualTo(expectedResponse)
   }
 
   @Test
@@ -64,7 +65,7 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
     val expectedResponse = HmppsBoldLrsExceptionHandler.ErrorResponse(
       HttpStatus.NOT_FOUND,
       "No Resource Found",
-      "No resource found failure: No static resource someUnknownEndpoint.",
+      "No resource found failure: No static resource someUnknownEndpoint for request '/someUnknownEndpoint'.",
       "Requested Resource not found on the server",
       moreInfo = "Requested Resource not found on the server",
     )
@@ -134,10 +135,10 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
       moreInfo = "A request timed out while waiting for a response from an upstream service.",
     )
 
-    val actualResponse = objectMapper.readValue(
+    val actualResponse = jsonMapper.readValue(
       webTestClient.post()
         .uri("/test/okhttp-timeout")
-        .headers(setAuthorisation(roles = listOf(ROLE_LEARNERS_RO)))
+        .headers(setAuthorisation(roles = listOf(Roles.ROLE_LEARNERS_RO)))
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.REQUEST_TIMEOUT)
@@ -147,7 +148,7 @@ class HmppsBoldLrsExceptionHandlerTest : IntegrationTestBase() {
       HmppsBoldLrsExceptionHandler.ErrorResponse::class.java,
     )
 
-    assertThat(actualResponse.copy(developerMessage = "dev message can vary")).isEqualTo(expectedResponse)
+    Assertions.assertThat(actualResponse.copy(developerMessage = "dev message can vary")).isEqualTo(expectedResponse)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/MatchStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/MatchStatusTest.kt
@@ -1,33 +1,34 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.models
 
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.exc.ValueInstantiationException
+import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 class MatchStatusTest {
 
-  private val objectMapper = jacksonObjectMapper()
+  private val jsonMapper = jsonMapper { addModule(kotlinModule()) }
 
   @Test
   fun `valid match status should parse`() {
-    objectMapper.readValue("\"Unmatched\"", MatchStatus::class.java)
-    objectMapper.readValue("\"Matched\"", MatchStatus::class.java)
-    objectMapper.readValue("\"Cannot be matched\"", MatchStatus::class.java)
+    jsonMapper.readValue("\"Unmatched\"", MatchStatus::class.java)
+    jsonMapper.readValue("\"Matched\"", MatchStatus::class.java)
+    jsonMapper.readValue("\"Cannot be matched\"", MatchStatus::class.java)
   }
 
   @Test
   fun `invalid match status should fail at runtime with an illegal argument exception`() {
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"STRAWBERRY\"", MatchStatus::class.java)
+      jsonMapper.readValue("\"STRAWBERRY\"", MatchStatus::class.java)
     }
 
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"2\"", MatchStatus::class.java)
+      jsonMapper.readValue("\"2\"", MatchStatus::class.java)
     }
 
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"1\"", MatchStatus::class.java)
+      jsonMapper.readValue("\"1\"", MatchStatus::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/GenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/models/request/GenderTest.kt
@@ -1,34 +1,35 @@
 package uk.gov.justice.digital.hmpps.learnerrecordsapi.models.request
 
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.exc.ValueInstantiationException
+import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 class GenderTest {
 
-  private val objectMapper = jacksonObjectMapper()
+  private val jsonMapper = jsonMapper { addModule(kotlinModule()) }
 
   @Test
   fun `valid gender should parse`() {
-    objectMapper.readValue("\"MALE\"", Gender::class.java)
-    objectMapper.readValue("\"FEMALE\"", Gender::class.java)
-    objectMapper.readValue("\"NOT_KNOWN\"", Gender::class.java)
-    objectMapper.readValue("\"NOT_SPECIFIED\"", Gender::class.java)
+    jsonMapper.readValue("\"MALE\"", Gender::class.java)
+    jsonMapper.readValue("\"FEMALE\"", Gender::class.java)
+    jsonMapper.readValue("\"NOT_KNOWN\"", Gender::class.java)
+    jsonMapper.readValue("\"NOT_SPECIFIED\"", Gender::class.java)
   }
 
   @Test
   fun `invalid gender should fail at runtime with an illegal argument exception`() {
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"STRAWBERRY\"", Gender::class.java)
+      jsonMapper.readValue("\"STRAWBERRY\"", Gender::class.java)
     }
 
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"2\"", Gender::class.java)
+      jsonMapper.readValue("\"2\"", Gender::class.java)
     }
 
     assertThrows<ValueInstantiationException> {
-      objectMapper.readValue("\"1\"", Gender::class.java)
+      jsonMapper.readValue("\"1\"", Gender::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/MatchResourceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/learnerrecordsapi/resource/MatchResourceTest.kt
@@ -205,7 +205,7 @@ class MatchResourceTest {
 }
 
 fun CheckMatchResponse.setStatus() = this.copy(
-  status = if (this.matchedUln.isNullOrEmpty() || this.matchedUln!!.isBlank()) {
+  status = if (this.matchedUln.isNullOrEmpty() || this.matchedUln.isBlank()) {
     CheckMatchStatus.NoMatch
   } else {
     CheckMatchStatus.Found


### PR DESCRIPTION
Version upgrade:
- plugin `uk.gov.justice.hmpps.gradle-spring-boot`: `10.0.4`
- Kotlin `2.3.10`
- dependencies:
  - `hmpps-kotlin-spring-boot-starter`, `hmpps-kotlin-spring-boot-starter-test`: `2.0.1`
  - `hmpps-sqs-spring-boot-starter`: `7.0.1`

Add dependencies (Spring starters/modules)
- `spring-boot-starter-flyway`

Add test dependencies (Spring starters/modules)
- `spring-boot-webtestclient`

revise artifact IDs of testcontainers (add prefix `testcontainers-` for localstack)

and more upgrade:
- `springdoc-openapi-starter-webmvc-ui` : `3.0.1`
- `swagger-parser`: `2.1.38`

Fixes during upgrade
- fixes for Nullability changes
- fixes for upgrading Jackson 3
- use jsonMapper (replace objectMapper)
- fix warnings
- use latest `LocalStackContainer`