### PR TITLE
ESWE-2041: Update dependencies, Helm charts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,20 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.3.1"
-  kotlin("plugin.spring") version "2.3.21"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.5.7"
+  kotlin("plugin.spring") version "2.4.0"
 }
 
 configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
-ext["postgresql.version"] = "42.7.11"
+ext["postgresql.version"] = "42.7.12"
+ext["jackson-2-bom.version"] = "2.21.5"
+ext["log4j2.version"] = "2.25.5"
+ext["tomcat.version"] = "11.0.24"
+ext["httpcore5.version"] = "5.4.3"
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.5.0")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
@@ -21,7 +25,7 @@ dependencies {
   implementation("javax.xml.bind:jaxb-api:2.3.1")
   implementation("org.glassfish.jaxb:jaxb-runtime:2.3.5")
   implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.1")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.4.0")
 
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
@@ -29,7 +33,7 @@ dependencies {
   implementation("com.h2database:h2")
   testImplementation("com.h2database:h2")
 
-  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.5.0")
   testImplementation("org.springframework.boot:spring-boot-webtestclient")
   testImplementation("org.wiremock:wiremock-standalone:3.13.2")
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.41") {

--- a/helm_deploy/hmpps-learner-records-api/Chart.yaml
+++ b/helm_deploy/hmpps-learner-records-api/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-learner-records-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.12"
+    version: "3.17.2"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: "1.17"
+    version: "1.17.1"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Update these:
- Gradle SB plugin `10.5.7`
- Kotlin lib `2.5.0`
- Helm charts
  - generic-service `3.17.2`
  - generic-prometheus-alerts `1.17.1`

Pin these:
- Jackson2 `2.21.5`
- log4j `2.25.5`
- tomcat `11.0.24`
- postgresql `42.7.12`
- httpcore5 `5.4.3`

More
- Kotlin `2.4.0`
- SQS lib `7.4.0`